### PR TITLE
Optimized database layout

### DIFF
--- a/src/dbUtils.ts
+++ b/src/dbUtils.ts
@@ -4,7 +4,7 @@ import { generateHash, ApiError } from './utils';
 import { SpraxAPIdbCfg, UserAgent, Skin, MinecraftUser, Cape, CapeType, MinecraftProfile } from './global';
 
 export class dbUtils {
-  private readonly pool: Pool | null = null;
+  private pool: Pool | null = null;
 
   constructor(dbCfg: SpraxAPIdbCfg) {
     if (dbCfg.enabled) {
@@ -371,7 +371,10 @@ export class dbUtils {
   shutdown(): Promise<void> {
     if (this.pool == null) return new Promise((resolve, _reject) => { resolve(); });
 
-    return this.pool.end();
+    const result = this.pool.end();
+    this.pool = null;
+
+    return result;
   }
 
   private shouldAbortTransaction(client: PoolClient, done: (release?: any) => void, err: Error): boolean {

--- a/src/dbUtils.ts
+++ b/src/dbUtils.ts
@@ -327,7 +327,7 @@ export class dbUtils {
       client.query('BEGIN', (err) => {
         if (this.shouldAbortTransaction(client, done, err)) return callback(err);
 
-        client.query(`SELECT EXISTS(SELECT * FROM (SELECT cape_id FROM cape_history WHERE profile_id =$1 AND cape_type =$2 ORDER BY added DESC LIMIT 1)x WHERE cape_id =$3);`,
+        client.query(`SELECT EXISTS(SELECT cape_id FROM (SELECT cape_id FROM(SELECT cape_id,added FROM cape_history WHERE profile_id =$1)x JOIN capes ON x.cape_id = capes.id AND capes.type =$2 ORDER BY x.added DESC LIMIT 1)x WHERE x.cape_id =$3);`,
           [mcUser.id, cape.type, cape.id], (err, res) => {
             if (this.shouldAbortTransaction(client, done, err)) return callback(err);
 
@@ -339,8 +339,8 @@ export class dbUtils {
                 callback(null);
               });
             } else {
-              client.query(`INSERT INTO cape_history(profile_id,cape_id,cape_type) VALUES($1,$2,$3);`,
-                [mcUser.id, cape.id, cape.type], (err, _res) => {
+              client.query(`INSERT INTO cape_history(profile_id,cape_id) VALUES($1,$2);`,
+                [mcUser.id, cape.id], (err, _res) => {
                   if (this.shouldAbortTransaction(client, done, err)) return callback(err);
 
                   client.query('COMMIT', (err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { Server, createServer } from 'http';
 import { dbUtils } from './dbUtils';
 import { SpraxAPIcfg, SpraxAPIdbCfg } from './global';
 
-let server: Server;
+let server: Server | null;
 export let db: dbUtils;
 export let cfg: SpraxAPIcfg = {
   listen: {
@@ -72,11 +72,14 @@ function shutdownHook() {
     process.exit();
   };
 
-  server.close((err) => {
-    if (err && err.message != 'Server is not running.') console.error(err);
+  if (server != null) {
+    server.close((err) => {
+      if (err && err.message != 'Server is not running.') console.error(err);
 
-    ready();
-  });
+      ready();
+    });
+    server = null;
+  }
 }
 
 process.on('SIGTERM', shutdownHook);


### PR DESCRIPTION
* Sometimes the shutdown-hook got called multiple times and caused some errors
* *cape_history* now won't hold *cape_type* as it is already hold inside *capes* and should not be done


* Mojang name-history lookups started to hit Mojang 429 causing a lot of error reporting and slow response time. Now saving a couple ms by directly contacting the fallback on multiple failures
* An index has been added for table *skins* on *original_url* speeding up queries quit a lot (CPU load went from 15.2 to 0.56)