### PR TITLE
Fix AI-Models not being loaded on linux

### DIFF
--- a/src/ai_predict.ts
+++ b/src/ai_predict.ts
@@ -54,8 +54,6 @@ export class AiModel {
    */
   async predict(image: Image | Buffer): Promise<{ className: string, probability: number }[]> {
     return new Promise(async (resolve, reject): Promise<void> => {
-      console.log('numTensors (start): ' + tf.memory().numTensors);
-
       const model = this.model;
       if (!model) return reject(new Error('AiModel has not been initialized correctly!'));
 

--- a/src/routes/skindb.ts
+++ b/src/routes/skindb.ts
@@ -23,11 +23,11 @@ async function initAiModels() {
 
   const aiModelDirs = fs.readdirSync(baseDir, { withFileTypes: true })
     .filter(dirent => dirent.isDirectory())
-    .map(dirent => dirent.name.toUpperCase());
+    .map(dirent => dirent.name);
 
   // Set to null as soon as possible, so when a requst comes in it does not responde with an 'unknown model'
   for (const dirName of aiModelDirs) {
-    AI_MODELS[dirName] = null;
+    AI_MODELS[dirName.toUpperCase()] = null;
   }
 
   new Promise((resolve) => {
@@ -35,8 +35,9 @@ async function initAiModels() {
 
     for (const dirName of aiModelDirs) {
       const dirPath = path.join(baseDir, dirName);
+      const aiKey = dirName.toUpperCase();
 
-      if (AI_MODELS[dirName] != null) {
+      if (AI_MODELS[aiKey] != null) {
         console.log('Found another AI-Model directory that has already been loaded:', dirPath);
         continue;
       }
@@ -46,7 +47,7 @@ async function initAiModels() {
 
         i++;
         model.init()
-          .then(() => AI_MODELS[dirName] = model)
+          .then(() => AI_MODELS[aiKey] = model)
           .catch((err) => { throw err; })
           .finally(() => {
             if (--i == 0) {
@@ -54,7 +55,7 @@ async function initAiModels() {
             }
           });
       } catch (err) {
-        AI_MODELS[dirName] = err;
+        AI_MODELS[aiKey] = err;
 
         console.error(`Could not load AI-Model '${dirName}': ${err instanceof Error ? err.message : err}`);
       }


### PR DESCRIPTION
As Linux allows case-sensitive file naming, TensorFlow can't find directories that are not already `toUpperCase()` (because the directory `GENDER` does not exist but `gender` does)