### PR TITLE
Discard fragments with alpha

### DIFF
--- a/src/utils/modelRender.ts
+++ b/src/utils/modelRender.ts
@@ -25,7 +25,7 @@ uniform sampler2D u_texture;
 
 void main(){
     gl_FragColor = texture2D(u_texture, vec2(v_texcoord.x, 1.0-v_texcoord.y));
-    if(gl_FragColor.w == 0.0)
+    if(gl_FragColor.w != 1.0)
         discard;
 }
 `;


### PR DESCRIPTION
Transparent fragment should not be rendered if the depth buffer is used